### PR TITLE
Fixes type annotation of on_failure for Future.

### DIFF
--- a/pyeffects/Future.py
+++ b/pyeffects/Future.py
@@ -226,7 +226,7 @@ class Future(Monad[A]):
             self.subscribers.append(subscriber)
             self.semaphore.release()
 
-    def on_failure(self, subscriber: Callable[[A], None]) -> None:
+    def on_failure(self, subscriber: Callable[[Exception], None]) -> None:
         """Calls a subscriber function when :class:`Future <Future>` completes with error.
 
         :param subscriber: function to call when :class:`Future` completes with error.
@@ -248,7 +248,7 @@ class Future(Monad[A]):
             return
 
         if self.is_failure():
-            subscriber(self.error)
+            subscriber(self.error())
 
         self.semaphore.release()
 

--- a/pyeffects/Try.py
+++ b/pyeffects/Try.py
@@ -159,7 +159,6 @@ class Try(Monad[A]):
         if self.is_success():
             func(self.value)
 
-
     def on_failure(self, func: Callable[[Exception], None]) -> None:
         """Calls a function on failure.
         


### PR DESCRIPTION
@sloboegen 

Fixes the signature of the `on_failure` method for `Future`.

The callable that is passed should take in an exception and do nothing w/ it b/c `on_failure` is explicitly meant to handle side-effecting from an exception.  i.e., i think the proper signature is `Callable[[Exception], None]` -> a function that takes in an exception and does nothing with it, just like your example that you provided in the docs.

```
def error():
  raise RuntimeError()
Future.run(error).on_failure(lambda _: print('ERROR!'))
```

The function being passed in takes an exception and returns nothing (None).